### PR TITLE
Moved to absolute path for hiera configs. Fixes #1.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -68,7 +68,7 @@ Vagrant.configure("2") do |config|
   #
   config.vm.provision :puppet do |puppet|
       ## tell Puppet where to find the hiera config
-      puppet.options = "--hiera_config hiera.yaml"
+      puppet.options = "--hiera_config /vagrant/puppet/manifests/hiera.yaml"
 
       ### boilerplate Vagrant/Puppet config
       puppet.manifests_path = "puppet/manifests"

--- a/puppet/manifests/hiera.yaml
+++ b/puppet/manifests/hiera.yaml
@@ -9,4 +9,4 @@
 :json:
     # @todo replace with absolute path for non-Vagrant use
     # alternatively set a top-level variable in default.pp and do %{::var_name}
-    :datadir: 'hieradata'
+    :datadir: '/vagrant/puppet/manifests/hieradata'

--- a/puppet/puppet_apply.sh
+++ b/puppet/puppet_apply.sh
@@ -2,9 +2,6 @@
 
 basedir="$( dirname $( readlink -f "${0}" ) )"
 
-## required for the relative datadir path in hiera.yaml
-cd ${basedir}/manifests
-
 exec puppet apply \
     --hiera_config ${basedir}/manifests/hiera.yaml \
     --modulepath ${basedir}/modules \


### PR DESCRIPTION
Quick fix for problem of missing hiera config. Uses absolute paths.
